### PR TITLE
Changed the used model for EventAttendeeController

### DIFF
--- a/code/controllers/EventRegisterController.php
+++ b/code/controllers/EventRegisterController.php
@@ -94,7 +94,7 @@ class EventRegisterController extends Page_Controller {
 		$registration = $this->getCurrentRegistration($forcewrite);
 		$nexturl = $this->Link('review');
 		$backurl = $this->canReview() ?	$nexturl : $this->Link();
-		$record = new Page(array(
+		$record = new RegistrableEvent(array(
 			'ID' => -1,
 			'Title' => $this->Title,
 			'ParentID' => $this->ID,


### PR DESCRIPTION
By changing the used model for EventAttendeeController from Page to RegistrableEvent the used template doesn't switch back to the default Page.ss template.